### PR TITLE
distroless image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,6 +25,7 @@ jobs:
         base-os:
           - fedora
           - debian
+          - distroless
     container:
       image: quay.io/buildah/stable:latest
       options: --security-opt seccomp=/usr/share/containers/seccomp.json --privileged

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -50,6 +50,20 @@ jobs:
           --index
           --annotation org.opencontainers.image.revision="${{ github.sha }}"
           ${{ needs.image-name.outputs.image-name }}
+
+      - name: Buildah Bud Debug
+        id: buildah-bud-debug
+        if: ${{ matrix.base-os == 'distroless' }}
+        run: >
+          buildah bud
+          --jobs=4
+          --platform=linux/amd64
+          --target=debug
+          --layers
+          --cache-from=ghcr.io/${{ needs.image-name.outputs.image-name }}/cache
+          --cache-to=ghcr.io/${{ needs.image-name.outputs.image-name }}/cache
+          -f ./${{ matrix.base-os }}.Containerfile
+          .
       - name: Buildah Bud
         id: buildah-bud
         run: >

--- a/.run/distroless.Containerfile debug.run.xml
+++ b/.run/distroless.Containerfile debug.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="distroless.Containerfile debug" type="docker-deploy" factoryName="dockerfile" server-name="podman">
+    <deployment type="dockerfile">
+      <settings>
+        <option name="imageTag" value="localhost/resdet:distroless-debug" />
+        <option name="buildCliOptions" value="--target=debug" />
+        <option name="buildOnly" value="true" />
+        <option name="sourceFilePath" value="distroless.Containerfile" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/distroless.Containerfile.run.xml
+++ b/.run/distroless.Containerfile.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="distroless.Containerfile" type="docker-deploy" factoryName="dockerfile" server-name="podman">
+    <deployment type="dockerfile">
+      <settings>
+        <option name="imageTag" value="localhost/resdet:distroless" />
+        <option name="buildOnly" value="true" />
+        <option name="sourceFilePath" value="distroless.Containerfile" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/distroless.Containerfile
+++ b/distroless.Containerfile
@@ -1,0 +1,61 @@
+FROM docker.io/library/debian:12-slim AS base
+
+WORKDIR /workdir
+
+RUN <<APT
+apt-get update
+apt-get --no-install-recommends install -y \
+    libpng16-16 \
+    libjpeg62-turbo \
+    libmjpegutils-2.1-0 \
+    libmagickwand-6.q16-6 \
+    libfftw3-bin \
+    # keep this line
+rm -rf /var/lib/apt/lists/*
+APT
+
+FROM base AS builder
+
+RUN <<APT
+apt-get update
+apt-get --no-install-recommends install -y \
+    build-essential \
+    libc-dev \
+    libpng-dev \
+    libjpeg62-turbo-dev \
+    libmjpegtools-dev \
+    libmagickwand-6.q16-dev \
+    libfftw3-dev \
+    # keep this line
+rm -rf /var/lib/apt/lists/*
+APT
+
+COPY . .
+RUN ./configure
+RUN make
+
+RUN <<CP
+mkdir -p /dist/usr/local/bin
+cp /workdir/resdet /dist/usr/local/bin
+cp /lib64/ld-linux-x86-64.so.2 --parents /dist
+ldd /workdir/resdet | awk 'NF == 4 { system("cp " $3 " --parents /dist") }'
+CP
+
+FROM gcr.io/distroless/static-debian12:debug AS debug
+
+COPY --from=builder /dist/ /
+
+# cachebust
+ENV I=1
+
+# this doesn't fail if something is missing
+ENV LD_TRACE_LOADED_OBJECTS=1
+RUN [ "/lib64/ld-linux-x86-64.so.2", "/usr/local/bin/resdet" ]
+
+ENTRYPOINT [ "/usr/local/bin/resdet" ]
+
+FROM gcr.io/distroless/static-debian12 AS runtime
+
+COPY --from=builder /dist/ /
+
+ENTRYPOINT [ "/usr/local/bin/resdet" ]


### PR DESCRIPTION
Here comes the [distroless](https://github.com/GoogleContainerTools/distroless) image variant.

This cannot be tested with the current CI-Testing methods because the test can't run in the image itself. It needs a complete rewrite of the tests to run on the host and execute via `docker`/`podman` (or run in a [podman-kind](https://gitlab.com/podman-kind/podman-kind)-container :-p). The scaling commands are also probably best, if the testfiles already come prepared with the repository to speed up CI and to save the environment by not burning resources on every push ;-)

![grafik](https://github.com/user-attachments/assets/1fa9ad44-05f1-4a4e-aa5d-77de6b31e7c4)
